### PR TITLE
Version 1.0.2

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -6,6 +6,14 @@ debugpy:
 http:
   server_port: 9124
 
+weather:
+  - platform: template
+    name: "My Weather Station"
+    condition_template: "{{ states('weather.weatherflow_day_based_forecast') }}"
+    temperature_template: "{{ states('sensor.weatherflow_air_temperature') | float }}"
+    humidity_template: "{{ states('sensor.weatherflow_relative_humidity') | float }}"
+    forecast_template: "{{ state_attr('weather.weatherflow_day_based_forecast', 'forecast') }}"
+
 logger:
   default: warning
   logs:

--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -6,14 +6,6 @@ debugpy:
 http:
   server_port: 9124
 
-weather:
-  - platform: template
-    name: "My Weather Station"
-    condition_template: "{{ states('weather.weatherflow_day_based_forecast') }}"
-    temperature_template: "{{ states('sensor.weatherflow_air_temperature') | float }}"
-    humidity_template: "{{ states('sensor.weatherflow_relative_humidity') | float }}"
-    forecast_template: "{{ state_attr('weather.weatherflow_day_based_forecast', 'forecast') }}"
-
 logger:
   default: warning
   logs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - Unreleased
+
+### Changed
+
+- Moved all shared attributes to the common entity definitions
+- Some code cleanup and linting.
+
 ## [1.0.1] - 2021-12-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [1.0.2] - Unreleased
+## [1.0.2] - 2022-01-02
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [1.1.0] - Unreleased
+## [1.0.2] - Unreleased
+
+### Fixed
+
+- The format of the forecast items could not work with the *weather template*. This was caused by the `datetime` attribute not being a string but a DateTime object.
 
 ### Changed
 
 - Moved all shared attributes to the common entity definitions
 - Some code cleanup and linting.
+- Removed `sunrise` and `sunset` attributes from the daily forecast. Use the `sun.sun` component instead.
 
 
 ## [1.0.1] - 2021-12-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Moved all shared attributes to the common entity definitions
 - Some code cleanup and linting.
 
+
 ## [1.0.1] - 2021-12-30
 
 ### Fixed

--- a/custom_components/weatherflow/binary_sensor.py
+++ b/custom_components/weatherflow/binary_sensor.py
@@ -69,6 +69,10 @@ async def async_setup_entry(
 class WeatherFlowBinarySensor(WeatherFlowEntity, BinarySensorEntity):
     """A WeatherFlow Binary Sensor."""
 
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-arguments
+    # Seven is reasonable in this case.
+
     def __init__(
         self,
         weatherflowapi,

--- a/custom_components/weatherflow/binary_sensor.py
+++ b/custom_components/weatherflow/binary_sensor.py
@@ -87,7 +87,6 @@ class WeatherFlowBinarySensor(WeatherFlowEntity, BinarySensorEntity):
             description,
             entries,
         )
-        self._attr_name = f"{DOMAIN.capitalize()} {self.entity_description.name}"
 
     @property
     def is_on(self):

--- a/custom_components/weatherflow/const.py
+++ b/custom_components/weatherflow/const.py
@@ -4,8 +4,6 @@ DOMAIN = "weatherflow"
 
 ATTR_DESCRIPTION = "description"
 ATTR_FORECAST_FEELS_LIKE = "feels_like"
-ATTR_FORECAST_SUNRISE = "sunrise"
-ATTR_FORECAST_SUNSET = "sunset"
 ATTR_FORECAST_WIND_GUST = "wind_gust"
 ATTR_FORECAST_UV = "uv_index"
 

--- a/custom_components/weatherflow/entity.py
+++ b/custom_components/weatherflow/entity.py
@@ -19,6 +19,10 @@ _LOGGER = logging.getLogger(__name__)
 class WeatherFlowEntity(Entity):
     """Base class for unifi protect entities."""
 
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-arguments
+    # Seven is reasonable in this case.
+
     def __init__(
         self,
         weatherflowapi,

--- a/custom_components/weatherflow/entity.py
+++ b/custom_components/weatherflow/entity.py
@@ -41,6 +41,7 @@ class WeatherFlowEntity(Entity):
         self.entry: ConfigEntry = entries
         self._attr_available = self.coordinator.last_update_success
         self._attr_unique_id = f"{description.key}_{self.station_data.key}"
+        self._attr_name = f"{DOMAIN.capitalize()} {self.entity_description.name}"
         self._attr_device_info = DeviceInfo(
             manufacturer=DEFAULT_BRAND,
             via_device=(DOMAIN, self.entry.unique_id),

--- a/custom_components/weatherflow/manifest.json
+++ b/custom_components/weatherflow/manifest.json
@@ -8,7 +8,7 @@
         "pyweatherflowrest==1.0.3"
     ],
     "dependencies": [],
-    "version": "1.0.1",
+    "version": "1.1.0",
     "codeowners": [
         "@briis"
     ],

--- a/custom_components/weatherflow/manifest.json
+++ b/custom_components/weatherflow/manifest.json
@@ -5,10 +5,10 @@
     "issue_tracker": "https://github.com/briis/hass-weatherflow/issues",
     "config_flow": true,
     "requirements": [
-        "pyweatherflowrest==1.0.3"
+        "pyweatherflowrest==1.0.6"
     ],
     "dependencies": [],
-    "version": "1.1.0",
+    "version": "1.0.2",
     "codeowners": [
         "@briis"
     ],

--- a/custom_components/weatherflow/sensor.py
+++ b/custom_components/weatherflow/sensor.py
@@ -595,7 +595,6 @@ class WeatherFlowSensor(WeatherFlowEntity, SensorEntity):
             description,
             entries,
         )
-        self._attr_name = f"{DOMAIN.capitalize()} {self.entity_description.name}"
         if self.entity_description.native_unit_of_measurement is None:
             self._attr_native_unit_of_measurement = unit_descriptions[
                 self.entity_description.unit_type

--- a/custom_components/weatherflow/sensor.py
+++ b/custom_components/weatherflow/sensor.py
@@ -576,6 +576,10 @@ async def async_setup_entry(
 class WeatherFlowSensor(WeatherFlowEntity, SensorEntity):
     """A WeatherFlow Sensor."""
 
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-arguments
+    # Eight is reasonable in this case.
+
     def __init__(
         self,
         weatherflowapi,

--- a/custom_components/weatherflow/weather.py
+++ b/custom_components/weatherflow/weather.py
@@ -98,6 +98,10 @@ async def async_setup_entry(
 class WeatherFlowWeatherEntity(WeatherFlowEntity, WeatherEntity):
     """A WeatherFlow Weather Entity."""
 
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-arguments
+    # Eight is reasonable in this case.
+
     def __init__(
         self,
         weatherflowapi,

--- a/custom_components/weatherflow/weather.py
+++ b/custom_components/weatherflow/weather.py
@@ -120,7 +120,6 @@ class WeatherFlowWeatherEntity(WeatherFlowEntity, WeatherEntity):
         self._attr_available = self.forecast_coordinator.last_update_success
         self.daily_forecast = self.entity_description.key in _WEATHER_DAILY
         self._is_metric = is_metric
-        self._attr_name = f"{DOMAIN.capitalize()} {self.entity_description.name}"
 
     @property
     def condition(self):

--- a/custom_components/weatherflow/weather.py
+++ b/custom_components/weatherflow/weather.py
@@ -29,8 +29,6 @@ from pyweatherflowrest.data import (
 
 from .const import (
     ATTR_FORECAST_FEELS_LIKE,
-    ATTR_FORECAST_SUNRISE,
-    ATTR_FORECAST_SUNSET,
     ATTR_FORECAST_WIND_GUST,
     ATTR_FORECAST_UV,
     CONDITION_CLASSES,
@@ -190,8 +188,6 @@ class WeatherFlowWeatherEntity(WeatherFlowEntity, WeatherEntity):
                     ATTR_FORECAST_TIME: item.utc_time,
                     ATTR_FORECAST_WIND_BEARING: item.wind_direction,
                     ATTR_FORECAST_WIND_SPEED: item.wind_avg,
-                    # ATTR_FORECAST_SUNRISE: utc_from_timestamp(item.sunrise),
-                    # ATTR_FORECAST_SUNSET: utc_from_timestamp(item.sunset),
                 }
                 ha_forecast_day.append(ha_item)
             return ha_forecast_day

--- a/custom_components/weatherflow/weather.py
+++ b/custom_components/weatherflow/weather.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-from typing import OrderedDict
 
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION,
@@ -20,7 +19,6 @@ from homeassistant.components.weather import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
-from homeassistant.util.dt import utc_from_timestamp
 
 from pyweatherflowrest.data import (
     ForecastDailyDescription,

--- a/custom_components/weatherflow/weather.py
+++ b/custom_components/weatherflow/weather.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import OrderedDict
 
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION,
@@ -172,36 +173,35 @@ class WeatherFlowWeatherEntity(WeatherFlowEntity, WeatherEntity):
         return getattr(self.coordinator.data, "visibility")
 
     @property
-    def forecast(self):
+    def forecast(self) -> list[Forecast] | None:
         """Return the forecast array."""
-        data: Forecast = []
+        ha_forecast_day: list[Forecast] = []
         if self.daily_forecast:
             forecast_data_daily: ForecastDailyDescription = getattr(
                 self.forecast_coordinator.data, "forecast_daily"
             )
             for item in forecast_data_daily:
-                data.append(
-                    {
-                        ATTR_FORECAST_TIME: item.utc_time,
-                        ATTR_FORECAST_TEMP: item.air_temp_high,
-                        ATTR_FORECAST_TEMP_LOW: item.air_temp_low,
-                        ATTR_FORECAST_PRECIPITATION: item.precip,
-                        ATTR_FORECAST_PRECIPITATION_PROBABILITY: item.precip_probability,
-                        ATTR_FORECAST_CONDITION: format_condition(item.icon),
-                        ATTR_FORECAST_WIND_SPEED: item.wind_avg,
-                        ATTR_FORECAST_WIND_BEARING: item.wind_direction,
-                        ATTR_FORECAST_SUNRISE: utc_from_timestamp(item.sunrise),
-                        ATTR_FORECAST_SUNSET: utc_from_timestamp(item.sunset),
-                    }
-                )
-            return data
+                ha_item = {
+                    ATTR_FORECAST_CONDITION: format_condition(item.icon),
+                    ATTR_FORECAST_PRECIPITATION: item.precip,
+                    ATTR_FORECAST_PRECIPITATION_PROBABILITY: item.precip_probability,
+                    ATTR_FORECAST_TEMP: item.air_temp_high,
+                    ATTR_FORECAST_TEMP_LOW: item.air_temp_low,
+                    ATTR_FORECAST_TIME: item.utc_time,
+                    ATTR_FORECAST_WIND_BEARING: item.wind_direction,
+                    ATTR_FORECAST_WIND_SPEED: item.wind_avg,
+                    # ATTR_FORECAST_SUNRISE: utc_from_timestamp(item.sunrise),
+                    # ATTR_FORECAST_SUNSET: utc_from_timestamp(item.sunset),
+                }
+                ha_forecast_day.append(ha_item)
+            return ha_forecast_day
 
-        data: Forecast = []
+        ha_forecast_hour: list[Forecast] = []
         forecast_data_hourly: ForecastHourlyDescription = getattr(
             self.forecast_coordinator.data, "forecast_hourly"
         )
         for item in forecast_data_hourly:
-            data.append(
+            ha_forecast_hour.append(
                 {
                     ATTR_FORECAST_TIME: item.utc_time,
                     ATTR_FORECAST_TEMP: item.air_temperature,
@@ -215,4 +215,4 @@ class WeatherFlowWeatherEntity(WeatherFlowEntity, WeatherEntity):
                     ATTR_FORECAST_UV: item.uv,
                 }
             )
-        return data
+        return ha_forecast_hour


### PR DESCRIPTION
### Fixed

- The format of the forecast items could not work with the *weather template*. This was caused by the `datetime` attribute not being a string but a DateTime object.

### Changed

- Moved all shared attributes to the common entity definitions
- Some code cleanup and linting.
- Removed `sunrise` and `sunset` attributes from the daily forecast. Use the `sun.sun` component instead.
